### PR TITLE
🐛 Avoid crashing binary sensor when prometheus is not available at startup

### DIFF
--- a/custom_components/prometheus_import/binary_sensor.py
+++ b/custom_components/prometheus_import/binary_sensor.py
@@ -36,8 +36,6 @@ async def async_setup_entry(
 
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
-    await coordinator.async_config_entry_first_refresh()
-
     async_add_entities([PrometheusAlertBinarySensor(coordinator, entry, hass)])
 
     _LOGGER.info("We finished the setup of prometheus_import *entity*")


### PR DESCRIPTION
This will make sure we handle boot correctly (especially if prometheus is not reachable when home assistant starts)

Change-Id: I28ba4359b74342be89a091643d66509effb171c5